### PR TITLE
Sets options to empty hash if nil

### DIFF
--- a/lib/casino/test_authenticator.rb
+++ b/lib/casino/test_authenticator.rb
@@ -4,7 +4,7 @@ require 'faker'
 class CASino::TestAuthenticator
   # @param [Hash] options
   def initialize(options)
-    @options = options
+    @options = options || {}
   end
 
   def validate(username, password)


### PR DESCRIPTION
Corrects NilError resulting when an email option is not passed in Casino cas.yml
